### PR TITLE
FIX source and target assembly compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
   <version>1.0-SNAPSHOT</version>
   <name>tracking</name>
   <url>http://maven.apache.org</url>
+   <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
mvn compile : it was creating compilation problems because the default targets did not exist during compilation.